### PR TITLE
Use Redis for task state management instead of the Dask Scheduler

### DIFF
--- a/dask_plugin.py
+++ b/dask_plugin.py
@@ -3,16 +3,16 @@ import click
 from redis import Redis
 from distributed.diagnostics.plugin import SchedulerPlugin
 
-from stochss_compute import RemoteSimulation
+from stochss_compute.api.delegate import DaskDelegateConfig
 
 class DaskWorkerPlugin(SchedulerPlugin):
     name = "test_plugin"
 
-    def __init__(self):
+    def __init__(self, redis_address, redis_port, redis_db):
         self.redis = Redis(
-            host="0.0.0.0",
-            port=6379,
-            db=0
+            host=redis_address,
+            port=redis_port,
+            db=redis_db
         )
 
     def transition(self, key, start, finish, *args, **kwargs):
@@ -24,5 +24,7 @@ class DaskWorkerPlugin(SchedulerPlugin):
 
 @click.command()
 def dask_setup(scheduler):
-    plugin = DaskWorkerPlugin()
+    config = DaskDelegateConfig()
+
+    plugin = DaskWorkerPlugin(config.redis_address, config.redis_port, config.redis_db)
     scheduler.add_plugin(plugin)

--- a/dask_plugin.py
+++ b/dask_plugin.py
@@ -3,6 +3,8 @@ import click
 from redis import Redis
 from distributed.diagnostics.plugin import SchedulerPlugin
 
+from stochss_compute import RemoteSimulation
+
 class DaskWorkerPlugin(SchedulerPlugin):
     name = "test_plugin"
 
@@ -18,7 +20,7 @@ class DaskWorkerPlugin(SchedulerPlugin):
         if start == "memory" and finish == "forgotten":
             finish = "done"
 
-        self.redis.set("test_key", finish)
+        self.redis.set(f"state-{key}", finish)
 
 @click.command()
 def dask_setup(scheduler):

--- a/dask_plugin.py
+++ b/dask_plugin.py
@@ -1,0 +1,26 @@
+import click
+
+from redis import Redis
+from distributed.diagnostics.plugin import SchedulerPlugin
+
+class DaskWorkerPlugin(SchedulerPlugin):
+    name = "test_plugin"
+
+    def __init__(self):
+        self.redis = Redis(
+            host="0.0.0.0",
+            port=6379,
+            db=0
+        )
+
+    def transition(self, key, start, finish, *args, **kwargs):
+        print(f"{key}: {finish}")
+        if start == "memory" and finish == "forgotten":
+            finish = "done"
+
+        self.redis.set("test_key", finish)
+
+@click.command()
+def dask_setup(scheduler):
+    plugin = DaskWorkerPlugin()
+    scheduler.add_plugin(plugin)

--- a/stochss_compute/api/delegate/__init__.py
+++ b/stochss_compute/api/delegate/__init__.py
@@ -1,1 +1,2 @@
 from .delegate import Delegate, DelegateConfig, JobStatus, JobState
+from .dask_delegate import DaskDelegate, DaskDelegateConfig

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -4,14 +4,15 @@ from pathlib import Path
 from typing import Callable
 
 from redis import Redis
-from dask.distributed import Future
-from dask.distributed import Client
-from dask.distributed import fire_and_forget
+from distributed import Future
+from distributed import Client
+from distributed import get_client
+from distributed import fire_and_forget
 
-from stochss_compute.api.delegate.delegate import Delegate
-from stochss_compute.api.delegate.delegate import JobState
-from stochss_compute.api.delegate.delegate import JobStatus
-from stochss_compute.api.delegate.delegate import DelegateConfig
+from .delegate import Delegate
+from .delegate import JobState
+from .delegate import JobStatus
+from .delegate import DelegateConfig
 
 class DaskDelegateConfig(DelegateConfig):
     redis_port = 6379

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -59,6 +59,10 @@ class DaskDelegate(Delegate):
         self.redis.set(f"{future.key}", str(outpath.resolve()))
         self.redis.save()
 
+        # Close the Client that started this job.
+        with get_client() as client:
+            client.close()
+
     def connect(self) -> bool:
         # No need to connect.
         return True

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -151,7 +151,12 @@ class DaskDelegate(Delegate):
         return results
 
     def job_complete(self, id: str) -> bool:
-        return self.redis.get(f"state-{id}") == "done"
+        redis_val = self.redis.get(f"state-{id}")
+
+        if redis_val is None:
+            return False
+
+        return redis_val.decode("utf-8") == "done"
 
     def job_exists(self, id: str) -> bool:
         return self.redis.get(f"state-{id}") is not None

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -91,8 +91,6 @@ class DaskDelegate(Delegate):
         # Create the state value in Redis.
         self.redis.set(f"state-{id}", "no-worker")
 
-        client.close()
-
         return True
 
     def stop_job(self, id: str) -> bool:

--- a/stochss_compute/api/delegate/redis_namespace.py
+++ b/stochss_compute/api/delegate/redis_namespace.py
@@ -1,0 +1,8 @@
+def vault_prefix(key: str) -> str:
+    return f"vault-{key}"
+
+def cache_prefix(key: str) -> str:
+    return f"cache-{key}"
+
+def state_prefix(key: str) -> str:
+    return f"state-{key}"


### PR DESCRIPTION
### Changes
- Added Dask plugin to enable task state updates to be automatically pushed onto Redis.
- Added Redis cache functionality to simulation results -- this is in preparation for data manipulation and visualization endpoints.
- Moved task state queries from the Dask scheduler onto Redis.
- Moved Results store onto the disk with Redis now acting as an index.
- Updated REST API to use new workflow.