### PR TITLE
Implementation of a results API endpoint to support proxy operations on cached data.

### DIFF
--- a/dask_plugin.py
+++ b/dask_plugin.py
@@ -3,16 +3,16 @@ import click
 from redis import Redis
 from distributed.diagnostics.plugin import SchedulerPlugin
 
-from stochss_compute import RemoteSimulation
+from stochss_compute.api.delegate import DaskDelegateConfig
 
 class DaskWorkerPlugin(SchedulerPlugin):
     name = "test_plugin"
 
-    def __init__(self):
+    def __init__(self, redis_address, redis_port, redis_db):
         self.redis = Redis(
-            host="0.0.0.0",
-            port=6379,
-            db=0
+            host=redis_address,
+            port=redis_port,
+            db=redis_db
         )
 
     def transition(self, key, start, finish, *args, **kwargs):
@@ -24,5 +24,7 @@ class DaskWorkerPlugin(SchedulerPlugin):
 
 @click.command()
 def dask_setup(scheduler):
-    plugin = DaskWorkerPlugin()
+    config = DaskDelegateConfig()
+
+    plugin = DaskWorkerPlugin(config.redis_address, config.redis_port, config.redis_db)
     scheduler.add_plugin(plugin)

--- a/dask_plugin.py
+++ b/dask_plugin.py
@@ -3,6 +3,8 @@ import click
 from redis import Redis
 from distributed.diagnostics.plugin import SchedulerPlugin
 
+from stochss_compute import RemoteSimulation
+
 class DaskWorkerPlugin(SchedulerPlugin):
     name = "test_plugin"
 
@@ -18,7 +20,7 @@ class DaskWorkerPlugin(SchedulerPlugin):
         if start == "memory" and finish == "forgotten":
             finish = "done"
 
-        self.redis.set("test_key", finish)
+        self.redis.set(f"state-{key}", finish)
 
 @click.command()
 def dask_setup(scheduler):

--- a/dask_plugin.py
+++ b/dask_plugin.py
@@ -1,0 +1,26 @@
+import click
+
+from redis import Redis
+from distributed.diagnostics.plugin import SchedulerPlugin
+
+class DaskWorkerPlugin(SchedulerPlugin):
+    name = "test_plugin"
+
+    def __init__(self):
+        self.redis = Redis(
+            host="0.0.0.0",
+            port=6379,
+            db=0
+        )
+
+    def transition(self, key, start, finish, *args, **kwargs):
+        print(f"{key}: {finish}")
+        if start == "memory" and finish == "forgotten":
+            finish = "done"
+
+        self.redis.set("test_key", finish)
+
+@click.command()
+def dask_setup(scheduler):
+    plugin = DaskWorkerPlugin()
+    scheduler.add_plugin(plugin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ redis>=3.5.3
 pydantic>=1.8.2
 dill
 requests
+jupyter
 
 gillespy2 @ git+https://github.com/StochSS/GillesPy2@develop

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup
+
+setup(name="stochss-compute",
+      version="0.0.1",
+      description="A compute delegation server for the StochSS family of stochastic simulators.",
+      author="Ethan Green",
+      author_email="egreen4@unca.edu",
+      url="https://github.com/StochSS/stochss-compute",
+ )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name="stochss-compute",
       version="0.0.1",

--- a/stochss_compute/api/api.py
+++ b/stochss_compute/api/api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from flask import Flask
 
 from .v1 import v1_api

--- a/stochss_compute/api/delegate/__init__.py
+++ b/stochss_compute/api/delegate/__init__.py
@@ -1,1 +1,2 @@
 from .delegate import Delegate, DelegateConfig, JobStatus, JobState
+from .dask_delegate import DaskDelegate, DaskDelegateConfig

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -96,7 +96,7 @@ class DaskDelegate(Delegate):
 
         # Create a job and set a callback to cache the results once complete.
         job_future: Future = self.client.submit(work, *function_args, **kwargs, key=job_id, pure=False)
-        # job_future.add_done_callback(self.__cache_results)
+        job_future.add_done_callback(self.__cache_results)
 
         # Publish the job as a dataset to maintain state across requests.
         self.client.publish_dataset(job_future, name=job_id, override=True)
@@ -108,13 +108,13 @@ class DaskDelegate(Delegate):
             return False
 
         # Iterate through the dependencies of this job.
-        # dependencies = self.client.run_on_scheduler(lambda dask_scheduler: [(state.key) for state in dask_scheduler.tasks[id].dependencies])
+        dependencies = self.client.run_on_scheduler(lambda dask_scheduler: [(state.key) for state in dask_scheduler.tasks[id].dependencies])
 
-        # # Filter out any weak depenencies. Strong dependencies are suffixed with "/" and the name of the job.
-        # dependencies = [(dependency) for dependency in dependencies if dependency.replace(id, "").startswith("/")]
+        # Filter out any weak depenencies. Strong dependencies are suffixed with "/" and the name of the job.
+        dependencies = [(dependency) for dependency in dependencies if dependency.replace(id, "").startswith("/")]
 
-        # futures = [(Future(key)) for key in dependencies]
-        # futures.append(Future(job_id))
+        futures = [(Future(key)) for key in dependencies]
+        futures.append(Future(job_id))
 
         self.client.cancel(Future(job_id))
         self.client.unpublish_dataset(job_id)

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -4,14 +4,15 @@ from pathlib import Path
 from typing import Callable
 
 from redis import Redis
-from dask.distributed import Future
-from dask.distributed import Client
-from dask.distributed import fire_and_forget
+from distributed import Future
+from distributed import Client
+from distributed import get_client
+from distributed import fire_and_forget
 
-from stochss_compute.api.delegate.delegate import Delegate
-from stochss_compute.api.delegate.delegate import JobState
-from stochss_compute.api.delegate.delegate import JobStatus
-from stochss_compute.api.delegate.delegate import DelegateConfig
+from .delegate import Delegate
+from .delegate import JobState
+from .delegate import JobStatus
+from .delegate import DelegateConfig
 
 class DaskDelegateConfig(DelegateConfig):
     redis_port = 6379

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -59,6 +59,10 @@ class DaskDelegate(Delegate):
         self.redis.set(f"{future.key}", str(outpath.resolve()))
         self.redis.save()
 
+        # Close the Client that started this job.
+        with get_client() as client:
+            client.close()
+
     def connect(self) -> bool:
         # No need to connect.
         return True

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -151,7 +151,12 @@ class DaskDelegate(Delegate):
         return results
 
     def job_complete(self, id: str) -> bool:
-        return self.redis.get(f"state-{id}") == "done"
+        redis_val = self.redis.get(f"state-{id}")
+
+        if redis_val is None:
+            return False
+
+        return redis_val.decode("utf-8") == "done"
 
     def job_exists(self, id: str) -> bool:
         return self.redis.get(f"state-{id}") is not None

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -1,22 +1,19 @@
-import dill
+import os
 
 from pathlib import Path
 from typing import Callable
 
-from redis import Redis
+import dill
+
 from distributed import Future
 from distributed import Client
-from distributed import Variable
 from distributed import get_client
+from distributed.scheduler import TaskState
 
 from .delegate import Delegate
 from .delegate import JobState
 from .delegate import JobStatus
 from .delegate import DelegateConfig
-
-from .redis_namespace import vault_prefix
-from .redis_namespace import cache_prefix
-from .redis_namespace import state_prefix
 
 class DaskDelegateConfig(DelegateConfig):
     redis_port = 6379
@@ -42,32 +39,27 @@ class DaskDelegate(Delegate):
     type: str = "dask"
 
     def __init__(self, delegate_config: DaskDelegateConfig):
+        super()
+
         self.cluster_address = f"tcp://{delegate_config.dask_cluster_address}:{delegate_config.dask_cluster_port}"
         self.delegate_config = delegate_config
-
-        # Connect to the Redis DB.
-        self.redis = Redis(
-            host=delegate_config.redis_address,
-            port=delegate_config.redis_port,
-            db=delegate_config.redis_db
-        )
 
         # Attempt to load the global Dask client.
         try:
             self.client = get_client()
-        except:
+
+        except ValueError as _:
             self.client = Client(self.cluster_address)
 
         # Setup functions to be run on the schedule.
-        def __scheduler_job_exists(dask_scheduler, id):
-            return id in dask_scheduler.tasks
+        def __scheduler_job_exists(dask_scheduler, job_id: str) -> bool:
+            return job_id in dask_scheduler.tasks
 
-        def __scheduler_job_state(dask_scheduler, id):
-            return dask_scheduler.tasks[id].state
+        def __scheduler_job_state(dask_scheduler, job_id: str) -> TaskState:
+            return dask_scheduler.tasks[job_id].state
 
         self.scheduler_job_exists = __scheduler_job_exists
         self.scheduler_job_state = __scheduler_job_state
-
 
     def __cache_results(self, future: Future):
         # Save the results in the vault.
@@ -80,8 +72,8 @@ class DaskDelegate(Delegate):
             result = dill.dumps(future.result())
             outfile.write(result)
 
-    def __job_state(self, id: str):
-        return self.client.run_on_scheduler(self.scheduler_job_state, id=id)
+    def __job_state(self, job_id: str) -> TaskState:
+        return self.client.run_on_scheduler(self.scheduler_job_state, id=job_id)
 
     def connect(self) -> bool:
         # No need to connect.
@@ -91,54 +83,53 @@ class DaskDelegate(Delegate):
         # Shim this out until I figure out a good way to test a Dask and Redis connection.
         return True
 
-    def create_job(self, id: str) -> bool:
+    def create_job(self, job_id: str) -> bool:
         # No concept of creating a job.
         return True
 
-    def start_job(self, id: str, work: Callable, *args, **kwargs) -> bool:
-        if self.job_exists(id) or self.job_complete(id):
+    def start_job(self, job_id: str, work: Callable, *args, **kwargs) -> bool:
+        if self.job_exists(job_id) or self.job_complete(job_id):
             return False
 
         # Parse *args and **kwargs for references to remote data.
         function_args = [(self.client.get_dataset(arg.replace("result://", "")) if isinstance(arg, str) and arg.startswith("result://") else arg) for arg in args]
 
         # Create a job and set a callback to cache the results once complete.
-        job_future: Future = self.client.submit(work, *function_args, **kwargs, key=id, pure=False)
+        job_future: Future = self.client.submit(work, *function_args, **kwargs, key=job_id, pure=False)
         # job_future.add_done_callback(self.__cache_results)
 
         # Publish the job as a dataset to maintain state across requests.
-        self.client.publish_dataset(job_future, name=id, override=True)
+        self.client.publish_dataset(job_future, name=job_id, override=True)
 
         return True
 
-    def stop_job(self, id: str) -> bool:
-        if not self.job_exists(id):
+    def stop_job(self, job_id: str) -> bool:
+        if not self.job_exists(job_id):
             return False
 
         # Iterate through the dependencies of this job.
-        dependencies = self.client.run_on_scheduler(lambda dask_scheduler: [(state.key) for state in dask_scheduler.tasks[id].dependencies])
+        # dependencies = self.client.run_on_scheduler(lambda dask_scheduler: [(state.key) for state in dask_scheduler.tasks[id].dependencies])
 
-        # Filter out any weak depenencies. Strong dependencies are suffixed with "/" and the name of the job.
-        dependencies = [(dependency) for dependency in dependencies if dependency.replace(id, "").startswith("/")]
+        # # Filter out any weak depenencies. Strong dependencies are suffixed with "/" and the name of the job.
+        # dependencies = [(dependency) for dependency in dependencies if dependency.replace(id, "").startswith("/")]
 
-        futures = [(Future(key)) for key in dependencies]
-        futures.append(Future(id))
+        # futures = [(Future(key)) for key in dependencies]
+        # futures.append(Future(job_id))
 
-        self.client.cancel(Future(id))
-        self.client.unpublish_dataset(id)
+        self.client.cancel(Future(job_id))
+        self.client.unpublish_dataset(job_id)
 
         # Hacky fix -- Simulation processes continue executing EVEN IF the parent task is killed.
         def hacky():
-            import os
             os.system("pkill -f 'Simulation.out'")
 
-        self.client.run(hacky)
+        self.client.run(hacky, nanny=True)
 
         return True
 
-    def job_status(self, id: str) -> JobStatus:
+    def job_status(self, job_id: str) -> JobStatus:
         # If the job is complete (results exist as a dataset or in the vault).
-        if self.job_complete(id):
+        if self.job_complete(job_id):
             status = JobStatus()
             status.status_id = JobState.DONE
             status.status_text = "The job is complete."
@@ -148,10 +139,10 @@ class DaskDelegate(Delegate):
             return status
 
         # If the job doesn't exist.
-        if not self.job_exists(id):
+        if not self.job_exists(job_id):
             status = JobStatus()
             status.status_id = JobState.DOES_NOT_EXIST
-            status.status_text = f"A job with id: '{id}' does not exist."
+            status.status_text = f"A job with job_id: '{job_id}' does not exist."
             status.has_failed = True
             status.is_done = False
 
@@ -168,7 +159,7 @@ class DaskDelegate(Delegate):
         }
 
         # Grab the task state from the scheduler.
-        future_status = self.__job_state(id)
+        future_status = self.__job_state(job_id)
 
         status = JobStatus()
         status.status_id = status_mapping[future_status][0]
@@ -179,16 +170,16 @@ class DaskDelegate(Delegate):
 
         return status
 
-    def job_results(self, id: str):
+    def job_results(self, job_id: str):
         # The results of this job may exist on the client dataset.
-        result_dataset = self.client.get_dataset(name=id).result()
+        result_dataset = self.client.get_dataset(name=job_id).result()
 
         if result_dataset is not None:
-            print(f"[DEBUG] Getting results from dataset.")
+            print("[DEBUG] Getting results from dataset.")
             return result_dataset
 
         # If the results are not in the cache, return from the disk.
-        results_file = Path(self.delegate_config.redis_vault_dir, id)
+        results_file = Path(self.delegate_config.redis_vault_dir, job_id)
 
         if not results_file.is_file():
             raise Exception(f"Results file '{results_file} does not exist in the vault.")
@@ -196,11 +187,10 @@ class DaskDelegate(Delegate):
         print(f"[DEBUG] Getting vaulted results from {results_file}.")
         return dill.loads(results_file.read_bytes())
 
-    def job_complete(self, id: str) -> bool:
+    def job_complete(self, job_id: str) -> bool:
         # Finished jobs must exist in the Vault (even if they exist within Redis or as a dataset).
-        return Path(self.delegate_config.redis_vault_dir, id).is_file()
+        return Path(self.delegate_config.redis_vault_dir, job_id).is_file()
 
-    def job_exists(self, id: str) -> bool:
+    def job_exists(self, job_id: str) -> bool:
         # Check if the job exists in the scheduler.
-        return self.client.run_on_scheduler(self.scheduler_job_exists, id=id)
-
+        return self.client.run_on_scheduler(self.scheduler_job_exists, job_id=job_id)

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -124,8 +124,15 @@ class DaskDelegate(Delegate):
         futures = [(Future(key)) for key in dependencies]
         futures.append(Future(id))
 
-        self.client.cancel(futures)
+        self.client.cancel(Future(id))
         self.client.unpublish_dataset(id)
+
+        # Hacky fix -- Simulation processes continue executing EVEN IF the parent task is killed.
+        def hacky():
+            import os
+            os.system("pkill -f 'Simulation.out'")
+
+        self.client.run(hacky)
 
         return True
 

--- a/stochss_compute/api/delegate/dask_delegate.py
+++ b/stochss_compute/api/delegate/dask_delegate.py
@@ -91,8 +91,6 @@ class DaskDelegate(Delegate):
         # Create the state value in Redis.
         self.redis.set(f"state-{id}", "no-worker")
 
-        client.close()
-
         return True
 
     def stop_job(self, id: str) -> bool:

--- a/stochss_compute/api/delegate/delegate.py
+++ b/stochss_compute/api/delegate/delegate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import IntEnum
 from abc import ABC, abstractmethod
 from typing import Callable
@@ -22,7 +24,7 @@ class DelegateConfig(ABC):
         Easy way to apply some number of named arguments onto self.
         """
 
-        self.__dict__ = self.__dict__ | kwargs
+        self.__dict__ = {**self.__dict__, **kwargs}
 
 class Delegate(ABC):
     type: str = ""

--- a/stochss_compute/api/delegate/delegate.py
+++ b/stochss_compute/api/delegate/delegate.py
@@ -53,7 +53,7 @@ class Delegate(ABC):
         pass
 
     @abstractmethod
-    def create_job(self, id: str) -> bool:
+    def create_job(self, job_id: str) -> bool:
         """
         Create a new job with the specified ID.
 
@@ -62,7 +62,7 @@ class Delegate(ABC):
         pass
 
     @abstractmethod
-    def start_job(self, id: str, work: Callable, *args, **kwargs) -> bool:
+    def start_job(self, job_id: str, work: Callable, *args, **kwargs) -> bool:
         """
         Start a job with the specified ID.
 
@@ -71,7 +71,7 @@ class Delegate(ABC):
         pass
 
     @abstractmethod
-    def stop_job(self, id: str) -> bool:
+    def stop_job(self, job_id: str) -> bool:
         """
         Stop a job with the specified ID.
 
@@ -80,7 +80,7 @@ class Delegate(ABC):
         pass
 
     @abstractmethod
-    def job_status(self, id: str) -> JobStatus:
+    def job_status(self, job_id: str) -> JobStatus:
         """
         Get the status of a job with the specified ID.
 
@@ -89,7 +89,7 @@ class Delegate(ABC):
         pass
 
     @abstractmethod
-    def job_results(self, id: str) -> str:
+    def job_results(self, job_id: str) -> str:
         """
         The raw results of a job with the specified ID.
 
@@ -98,7 +98,7 @@ class Delegate(ABC):
         pass
 
     @abstractmethod
-    def job_exists(self, id: str) -> bool:
+    def job_exists(self, job_id: str) -> bool:
         """
         Check if a job with the specified ID exists in the delegate.
 
@@ -107,7 +107,7 @@ class Delegate(ABC):
         pass
 
     @abstractmethod
-    def job_complete(self, id: str) -> bool:
+    def job_complete(self, job_id: str) -> bool:
         """
         Check if a job with the specified ID is complete.
 

--- a/stochss_compute/api/delegate/redis_namespace.py
+++ b/stochss_compute/api/delegate/redis_namespace.py
@@ -1,0 +1,8 @@
+def vault_prefix(key: str) -> str:
+    return f"vault-{key}"
+
+def cache_prefix(key: str) -> str:
+    return f"cache-{key}"
+
+def state_prefix(key: str) -> str:
+    return f"state-{key}"

--- a/stochss_compute/api/v1/__init__.py
+++ b/stochss_compute/api/v1/__init__.py
@@ -1,7 +1,11 @@
 from flask import Blueprint
-from stochss_compute.api.v1.job import v1_job
+
+from .job import v1_job
+from .result import v1_result
 
 v1_api = Blueprint("stochss-compute API V1", __name__, url_prefix="/api/v1")
+
 v1_api.register_blueprint(v1_job)
+v1_api.register_blueprint(v1_result)
 
 print("V1 API has been initialized.")

--- a/stochss_compute/api/v1/apiutils.py
+++ b/stochss_compute/api/v1/apiutils.py
@@ -1,0 +1,22 @@
+from flask import g
+from flask import current_app
+
+from werkzeug.local import LocalProxy
+
+from ..delegate import Delegate
+
+def get_delegate():
+    if "delegate" in g:
+        return g.delegate
+
+    delegate_config = current_app.config["DELEGATE_CONFIG"]
+    delegate_type = current_app.config["DELEGATE_TYPE"]
+
+    delegate = delegate_type(delegate_config)
+
+    if False in (delegate.connect(), delegate.test_connection()):
+        raise Exception("Delegate connection failed.")
+
+    return delegate
+
+delegate: Delegate = LocalProxy(get_delegate)

--- a/stochss_compute/api/v1/job.py
+++ b/stochss_compute/api/v1/job.py
@@ -1,13 +1,10 @@
 from gillespy2.core import Model
 from pydantic import BaseModel
 
-from flask import g
 from flask import request
 from flask import Blueprint
-from flask import current_app
-from flask import make_response
 
-from werkzeug.local import LocalProxy
+from .apiutils import delegate
 
 class StartJobRequest(BaseModel):
     job_id: str
@@ -34,22 +31,6 @@ class ErrorResponse(BaseModel):
     msg: str
 
 v1_job = Blueprint("V1 Job API Endpoint", __name__, url_prefix="/job")
-
-def get_delegate():
-    if "delegate" in g:
-        return g.delegate
-
-    delegate_config = current_app.config["DELEGATE_CONFIG"]
-    delegate_type = current_app.config["DELEGATE_TYPE"]
-
-    delegate = delegate_type(delegate_config)
-
-    if False in (delegate.connect(), delegate.test_connection()):
-        raise Exception("Delegate connection failed.")
-
-    return delegate
-
-delegate = LocalProxy(get_delegate)
 
 @v1_job.route("/start", methods=["POST"])
 def start_job():

--- a/stochss_compute/api/v1/result.py
+++ b/stochss_compute/api/v1/result.py
@@ -33,7 +33,7 @@ def results_exist(result_id: str):
 
     return "True", 200
 
-@v1_result.route("/<string:result_id>/plot", methods=["GET"])
+@v1_result.route("/<string:result_id>/plotplotly", methods=["GET"])
 def make_plot(result_id: str):
     # Ensure that a result with this ID exists.
     if not delegate.job_complete(result_id):

--- a/stochss_compute/api/v1/result.py
+++ b/stochss_compute/api/v1/result.py
@@ -61,7 +61,7 @@ def make_average_ensemble(result_id: str):
     return StartJobResponse(
         job_id=job_id,
         msg="The job has been successfully started.",
-        status=f"/v1/job/{results_hash}/status"
+        status=f"/v1/job/{job_id}/status"
     ).json(), 202
 
 @v1_result.route("/<string:result_id>/plot", methods=["GET"])

--- a/stochss_compute/api/v1/result.py
+++ b/stochss_compute/api/v1/result.py
@@ -51,7 +51,6 @@ def make_average_ensemble(result_id: str):
             status=f"/v1/job/{job_id}/status"
         ).json(), 202
 
-    from gillespy2.core import Results
     delegate.start_job(job_id, Results.average_ensemble, f"result://{result_id}")
 
     return StartJobResponse(

--- a/stochss_compute/api/v1/result.py
+++ b/stochss_compute/api/v1/result.py
@@ -1,0 +1,56 @@
+import bz2
+import dill
+
+import plotly.io as plotlyio
+
+from flask import Blueprint
+from flask import make_response
+from gillespy2.core import Results
+
+from .apiutils import delegate
+from .job import ErrorResponse
+
+v1_result = Blueprint("V1 Result API Endpoint", __name__, url_prefix="result/")
+
+@v1_result.route("/<string:result_id>/get", methods=["GET"])
+def get_results(result_id: str):
+    if not delegate.job_complete(result_id):
+        return ErrorResponse(msg="A result with this ID does not yet exist."), 404
+
+    results_json = delegate.job_results(result_id).to_json()
+    compressed_results = bz2.compress(results_json.encode())
+
+    response = make_response(compressed_results)
+    response.headers["Content-Encoding"] = "bzip2"
+
+    return response, 200
+
+
+@v1_result.route("/<string:result_id>/exists", methods=["GET"])
+def results_exist(result_id: str):
+    if not delegate.job_complete(result_id):
+        return "False", 404
+
+    return "True", 200
+
+@v1_result.route("/<string:result_id>/plot", methods=["GET"])
+def make_plot(result_id: str):
+    # Ensure that a result with this ID exists.
+    if not delegate.job_complete(result_id):
+        return "Something broke", 404
+
+    # Grab the results.
+    results: Results = delegate.job_results(result_id)
+
+    # Plot the figure without rendering, returning the backing datastructure.
+    results_plot = results.plotplotly(return_plotly_figure=True)
+
+    # Generate plot JSON, encode, and compress.
+    plot_json = plotlyio.to_json(results_plot)
+    compressed_plot = bz2.compress(plot_json.encode())
+
+    # Create and return the HTTP response.
+    response = make_response(compressed_plot)
+    response.headers["Content-Encoding"] = "bzip2"
+
+    return response, 200

--- a/stochss_compute/compute_server.py
+++ b/stochss_compute/compute_server.py
@@ -1,0 +1,41 @@
+import requests
+
+from enum import Enum
+
+from urllib.parse import urljoin
+from urllib.parse import urlparse
+
+from pydantic import BaseModel
+
+class Endpoint(Enum):
+    JOB = 1
+    RESULT = 2
+
+class ComputeServer():
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+        self.address = f"http://{host}:{port}/api/v1"
+
+        self.job_api = f"{self.address}/job"
+        self.result_api = f"{self.address}/result"
+
+        self.endpoints = {
+            Endpoint.JOB: self.job_api,
+            Endpoint.RESULT: self.result_api
+        }
+
+    def get(self, endpoint: Endpoint, sub: str) -> requests.Response:
+        print(f"{self.endpoints[endpoint]}{sub}")
+        return requests.get(f"{self.endpoints[endpoint]}{sub}")
+
+    def post(self, endpoint: Endpoint, sub: str, request: BaseModel = None) -> requests.Response:
+        url = f"{self.endpoints[endpoint]}{sub}"
+        print(url)
+
+        if request is None:
+            return requests.post(url)
+
+        return requests.post(url, json=request.json())
+

--- a/stochss_compute/remote_results.py
+++ b/stochss_compute/remote_results.py
@@ -109,6 +109,9 @@ class RemoteResults(Results):
 
         return results
 
+    def cancel(self):
+        stop_response = self.server.post(Endpoint.JOB, f"/{self.result_id}/stop")
+
     def hook_average_ensemble(self, *args, **kwargs):
         status_response = self.server.get(Endpoint.JOB, f"/{self.result_id}/status")
         status: JobStatusResponse = unwrap_or_err(JobStatusResponse, status_response)

--- a/stochss_compute/remote_results.py
+++ b/stochss_compute/remote_results.py
@@ -7,10 +7,10 @@ from functools import partial
 
 import plotly.io as plotlyio
 
+from IPython.display import Image
+
 from gillespy2.core import Model
 from gillespy2.core import Results
-
-from .remote_utils import unwrap_or_err
 
 from .compute_server import Endpoint
 from .compute_server import ComputeServer
@@ -86,6 +86,15 @@ class RemoteResults(Results):
         results = Results.from_json(results_json)
 
         return results
+
+    def hook_plot(self, *args, **kwargs):
+        plot_response = self.server.get(Endpoint.RESULT, f"/{self.result_id}/plot")
+
+        print(f"Plot size: {sys.getsizeof(plot_response.content)}")
+        plot_image = bz2.decompress(plot_response.content)
+        print(f"Expanded to: {sys.getsizeof(plot_image)}")
+
+        return Image(data=plot_image, format="png")
 
     def hook_plotplotly(self, *args, **kwargs):
         plot_response = self.server.get(Endpoint.RESULT, f"/{self.result_id}/plotplotly")

--- a/stochss_compute/remote_results.py
+++ b/stochss_compute/remote_results.py
@@ -1,0 +1,82 @@
+import sys
+import bz2
+import time
+
+import plotly.io as plotlyio
+
+from gillespy2.core import Model
+from gillespy2.core import Results
+
+from .remote_utils import unwrap_or_err
+
+from .compute_server import Endpoint
+from .compute_server import ComputeServer
+
+from .api.v1.job import ErrorResponse
+from .api.v1.job import JobStatusResponse
+
+class RemoteResults(Results):
+    def __init__(self, result_id: str, server: ComputeServer, model: Model):
+        self.result_id = result_id
+        self.server = server
+        self.model = model
+
+    def __poll_job_status(self) -> bool:
+        # Request the status of a running job.
+        status_response = self.server.get(Endpoint.JOB, f"/{self.result_id}/status")
+
+        if not status_response.ok:
+            raise Exception(ErrorResponse.parse_raw(status_response.text).msg)
+
+        # Parse the body of the response into a JobStatusResponse object.
+        status = JobStatusResponse.parse_raw(status_response.text)
+
+        return status.is_complete
+
+    def status(self) -> JobStatusResponse:
+        """
+        Get the status of the remote job.
+
+        :returns: JobStatusResponse
+        """
+
+    def resolve(self) -> Results:
+        """
+        Finish the remote job and return the results.
+        This function will block until the remote job is complete.
+
+        :returns: Results
+        """
+
+        # Poll the job status until it finishes.
+        while not self.__poll_job_status():
+            time.sleep(5)
+
+        # Request the results of the finished job.
+        results_response = self.server.get(Endpoint.RESULT, f"/{self.result_id}/get")
+
+        if not results_response.ok:
+            raise Exception(ErrorResponse.parse_raw(results_response.text).msg)
+
+        print(f"Results size: {sys.getsizeof(results_response.content)}")
+        results_json = bz2.decompress(results_response.content).decode()
+        print(f"Expanded to: {sys.getsizeof(results_json)}")
+
+        # Parse and return the response body into a valid Results object.
+        results = Results.from_json(results_json)
+
+        return results
+
+    def plotplotly(self):
+        plot_response = self.server.get(Endpoint.RESULT, f"/{self.result_id}/plot")
+        
+        print(f"Plot size: {sys.getsizeof(plot_response.content)}")
+        plot_json = bz2.decompress(plot_response.content).decode()
+        print(f"Expanded to: {sys.getsizeof(plot_json)}")
+
+        with open("test", "w") as outfile:
+            outfile.write(plot_json)
+
+        plot = plotlyio.from_json(plot_json)
+        plot.show()
+

--- a/stochss_compute/remote_results.py
+++ b/stochss_compute/remote_results.py
@@ -67,8 +67,8 @@ class RemoteResults(Results):
 
         return results
 
-    def plotplotly(self):
-        plot_response = self.server.get(Endpoint.RESULT, f"/{self.result_id}/plot")
+    def hook_plotplotly(self, *args, **kwargs):
+        plot_response = self.server.get(Endpoint.RESULT, f"/{self.result_id}/plotplotly")
         
         print(f"Plot size: {sys.getsizeof(plot_response.content)}")
         plot_json = bz2.decompress(plot_response.content).decode()

--- a/stochss_compute/remote_simulation.py
+++ b/stochss_compute/remote_simulation.py
@@ -1,9 +1,18 @@
-import time
+import bz2
+import sys
 import json
-import requests
+
+import plotly.io as plotlyio
 
 from gillespy2.core import Model
 from gillespy2.core import Results
+
+from .remote_utils import unwrap_or_err
+
+from .compute_server import Endpoint
+from .compute_server import ComputeServer
+
+from .remote_results import RemoteResults
 
 from .api.v1.job import (
     StartJobRequest,
@@ -12,12 +21,6 @@ from .api.v1.job import (
     JobStopResponse,
     ErrorResponse
 )
-
-class ComputeServer():
-    def __init__(self, host, port):
-        self.host = host
-        self.port = port
-        self.address = f"http://{host}:{port}"
 
 class RemoteSimulation():
     @classmethod
@@ -30,10 +33,10 @@ class RemoteSimulation():
         :type server: ComputeServer
         """
 
-        sim = RemoteSimulation()
-        sim.server = server
+        return RemoteSimulation(server)
 
-        return sim
+    def __init__(self, server: ComputeServer):
+        self.server = server
 
     def with_model(self, model: Model):
         """
@@ -47,7 +50,7 @@ class RemoteSimulation():
 
         return self
 
-    def run(self, **params) -> Results:
+    def run(self, **params) -> RemoteResults:
         """
         Simulate the Model on the target ComputeServer, returning the results once complete.
 
@@ -61,55 +64,52 @@ class RemoteSimulation():
         model_hash = self.model.get_json_hash()
         model = self.model.to_json()
 
-        request = StartJobRequest(
-            job_id=model_hash,
-            model=model
-        )
+        remote_results = RemoteResults(result_id=model_hash, server=self.server, model=self.model)
 
-        # Check to see if the job exists.
-        exists_response = requests.get(f"{self.server.address}/api/v1/job/{model_hash}/results")
-        if exists_response.status_code == 200:
-            return Results.from_json(exists_response.text)
+        # Check to see if results already exist for this ID.
+        results_response = self.server.get(Endpoint.RESULT, f"/{model_hash}/exists")
 
-        start_raw = requests.post(f"{self.server.address}/api/v1/job/start", json=request.json())
+        # If this query returns a 200 then a result with this ID exists.
+        if results_response.ok:
+            return remote_results 
 
-        if start_raw.status_code != 202:
-            print(start_raw)
-            error = ErrorResponse.parse_raw(start_raw.text)
+        # Get the status of a job with this ID.
+        status_response = self.server.get(Endpoint.JOB, f"/{model_hash}/status")
 
-            raise Exception(error.msg)
+        # If the job exists and it hasn't failed, return the RemoteResult.
+        if status_response.ok and not JobStatusResponse.parse_raw(status_response.text).has_failed:
+            return remote_results
 
-        start_response = StartJobResponse.parse_raw(start_raw.text)
+        # If we make it this far then the job either doesn't exist or has failed. Either way, start a new one.
+        start_request = StartJobRequest(job_id=model_hash, model=model)
+        start_response = self.server.post(Endpoint.JOB, "/start", request=start_request)
 
-        status_url = f"{self.server.address}/api{start_response.status}"
-        print(status_url)
-        status_raw = requests.get(status_url)
+        # Attempt to unwrap the response. If the request failed though, raise an Exception.
+        unwrap_or_err(StartJobResponse, start_response)
 
-        if status_raw.status_code != 200:
-            error = ErrorResponse.parse_raw(status_raw.text)
-            raise Exception(error.msg)
+        # Looks like everything went well, return the RemoteResult.
+        return remote_results
 
-        job_status = self.__get_job_status(status_url)
+    def test_plot(self):
+        plot_response = self.server.get(Endpoint.RESULT, f"/{self.model.get_json_hash()}/plot")
+        # plot_request = requests.get(f"{self.server.address}/api/v1/result/{self.model.get_json_hash()}/plot")
 
-        while not job_status.is_complete:
-            time.sleep(5)
+        print(f"Plot size: {sys.getsizeof(plot_response.content)}")
+        plot_json = bz2.decompress(plot_response.content).decode()
 
-            job_status = self.__get_job_status(status_url)
+        with open("test", "w") as outfile:
+            outfile.write(plot_json)
 
-        results_raw = requests.get(f"{self.server.address}/api/v1/job/{request.job_id}/results")
-
-        if results_raw.status_code != 200:
-            error = ErrorResponse.parse_raw(results_raw.text)
-            raise Exception(error.msg)
-
-        return Results.from_json(results_raw.text)
+        plot = plotlyio.from_json(plot_json)
+        plot.show()
 
     def __get_job_status(self, status_url: str) -> JobStatusResponse:
-        status_raw = requests.get(status_url)
+        status_response  = self.server.get(Endpoint.JOB, status_url)
+        # status_raw = requests.get(status_url)
 
-        if status_raw.status_code != 200:
-            error = ErrorResponse.parse_raw(status_raw.text)
+        if status_response.status_code != 200:
+            error = ErrorResponse.parse_raw(status_response.text)
             raise Exception(error)
 
-        return JobStatusResponse.parse_raw(status_raw.text)
+        return JobStatusResponse.parse_raw(status_response.text)
 

--- a/stochss_compute/remote_simulation.py
+++ b/stochss_compute/remote_simulation.py
@@ -64,7 +64,7 @@ class RemoteSimulation():
         model_hash = self.model.get_json_hash()
         model = self.model.to_json()
 
-        remote_results = RemoteResults(result_id=model_hash, server=self.server, model=self.model)
+        remote_results = RemoteResults(result_id=model_hash, server=self.server)
 
         # Check to see if results already exist for this ID.
         results_response = self.server.get(Endpoint.RESULT, f"/{model_hash}/exists")
@@ -81,7 +81,7 @@ class RemoteSimulation():
             return remote_results
 
         # If we make it this far then the job either doesn't exist or has failed. Either way, start a new one.
-        start_request = StartJobRequest(job_id=model_hash, model=model)
+        start_request = StartJobRequest(job_id=model_hash, model=model, args="", kwargs=params)
         start_response = self.server.post(Endpoint.JOB, "/start", request=start_request)
 
         # Attempt to unwrap the response. If the request failed though, raise an Exception.

--- a/stochss_compute/remote_utils.py
+++ b/stochss_compute/remote_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from requests import Response
 from pydantic import BaseModel
 

--- a/stochss_compute/remote_utils.py
+++ b/stochss_compute/remote_utils.py
@@ -1,0 +1,10 @@
+from requests import Response
+from pydantic import BaseModel
+
+from .api.v1.job import ErrorResponse
+
+def unwrap_or_err(response_model: type[BaseModel], response: Response):
+    if not response.ok:
+        raise Exception(ErrorResponse.parse_raw(response.text).msg)
+
+    return response_model.parse_raw(response.text)


### PR DESCRIPTION
Note that this PR is dependent on changes made in PR #26.

### Changes
- Added result API endpoint: `/api/v1/result*` which contains endpoints that allow for clients to interact with cached / vaulted `gillespy2#Result` objects as though they were locally available. Queried data is compressed via `bzip2`. The following endpoints have been implemented:
  - `/<string:result_id>/get`: If available, compresses and returns the result object.
  - `/<string:result_id>/exists`: Returns a "boolean" value based on whether a results object exists with ID `result_id`.
  - `/<string:result_id>/plotplotly`: Plots the object with `Results#plotplotly`, converts the figure to JSON, compresses, and returns to the client.
  - `/<string:result_id>/average_ensemble`: Computes `Results#average_ensemble` and returns the results to the client.
  - `/<string:result_id>/plot`: Plots the object with `Results#plot`, grabs the image, compresses it, and returns it to the client.
- Split `remote_simulation.py` into three classes: `RemoteSimulation`, `ComputeServer` and `RemoteResult`.
  - `ComputeServer` handles HTTP communication between client and API.
  - `RemoteResult` maintains job / result state and proxies commands between client and API.
