### PR TITLE
Fixed ImportError exceptions in clients where Flask is not installed.

### DIFF
--- a/stochss_compute/api/__init__.py
+++ b/stochss_compute/api/__init__.py
@@ -1,4 +1,6 @@
 try:
-    from .api import start_api
+    import flask
 except ImportError:
     pass
+else:
+    from .api import start_api

--- a/stochss_compute/api/__init__.py
+++ b/stochss_compute/api/__init__.py
@@ -1,1 +1,4 @@
-from .api import start_api
+try:
+    from .api import start_api
+except ImportError:
+    pass

--- a/stochss_compute/api/dataclass.py
+++ b/stochss_compute/api/dataclass.py
@@ -1,0 +1,67 @@
+from typing import Any
+from typing import List
+from typing import Dict
+
+import gillespy2;
+from pydantic import BaseModel
+
+class ErrorResponse(BaseModel):
+    msg: str
+
+class StartJobRequest(BaseModel):
+    job_id: str
+    model: str
+    args: str
+    kwargs: str
+
+class StartJobResponse(BaseModel):
+    job_id: str
+    msg: str
+    status: str
+
+class JobStatusResponse(BaseModel):
+    job_id: str
+    status_id: int
+    status_msg: str
+    is_complete: bool
+    has_failed: bool
+
+class JobStopResponse(BaseModel):
+    job_id: str
+    msg: str
+    success: bool
+
+class BaseModel(BaseModel):
+    pass
+
+class Model(gillespy2.Model):
+    @classmethod
+    def __serialize__(cls, value: "Model") -> str:
+        return value.to_json()
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value) -> "Model":
+        if isinstance(value, str):
+            return cls(Model.from_json(value))
+
+        return value
+
+class ModelRunRequest(BaseModel):
+    model: Model
+    args: List = []
+    kwargs: Dict = {}
+
+    class Config:
+        json_encoders = {gillespy2.core.Model: lambda model: Model.__serialize__(model)}
+
+class PlotPlotlyRequest(BaseModel):
+    result_id: str
+    args: List[str] = []
+    kwargs: Dict[str, Any] = {}
+
+class AverageEnsembleRequest(BaseModel):
+    result_id: str

--- a/stochss_compute/api/v1/dataclass.py
+++ b/stochss_compute/api/v1/dataclass.py
@@ -1,4 +1,0 @@
-from pydantic import BaseModel
-
-class ErrorResponse(BaseModel):
-    msg: str

--- a/stochss_compute/api/v1/gillespy2/dataclass.py
+++ b/stochss_compute/api/v1/gillespy2/dataclass.py
@@ -1,5 +1,0 @@
-import pydantic
-import gillespy2.core
-
-class BaseModel(pydantic.BaseModel):
-    pass

--- a/stochss_compute/api/v1/gillespy2/model.py
+++ b/stochss_compute/api/v1/gillespy2/model.py
@@ -1,45 +1,21 @@
 import os
 
-from typing import List
-from typing import Dict
+from stochss_compute.api.dataclass import (
+    ErrorResponse,
+    ModelRunRequest,
+    JobStatusResponse
+)
 
 from ..apiutils import delegate
-from ..job import JobStatusResponse
-from ..dataclass import ErrorResponse
 
 import gillespy2.core
 
 from flask import request
 from flask import Blueprint
 
-from pydantic import BaseModel
 from pydantic import ValidationError
 
 model_endpoint = Blueprint("V1 GillesPy2 Model API Endpoint", __name__, url_prefix="/model")
-
-class Model(gillespy2.core.Model):
-    @classmethod
-    def __serialize__(cls, value: "Model") -> str:
-        return value.to_json()
-
-    @classmethod
-    def __get_validators__(cls):
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, value) -> "Model":
-        if isinstance(value, str):
-            return cls(Model.from_json(value))
-
-        return value
-
-class ModelRunRequest(BaseModel):
-    model: Model
-    args: List = []
-    kwargs: Dict = {}
-
-    class Config:
-        json_encoders = {gillespy2.core.Model: lambda model: Model.__serialize__(model)}
 
 @model_endpoint.route("/run", methods=["POST"])
 def run():

--- a/stochss_compute/api/v1/gillespy2/results.py
+++ b/stochss_compute/api/v1/gillespy2/results.py
@@ -1,28 +1,20 @@
-from typing import Any
-from typing import List
-from typing import Dict
-
+from msilib.schema import Error
 from ..apiutils import delegate
-from ..job import JobStatusResponse
-from ..dataclass import ErrorResponse
+from stochss_compute.api.dataclass import (
+    ErrorResponse,
+    PlotPlotlyRequest,
+    JobStatusResponse,
+    AverageEnsembleRequest
+)
 
 from gillespy2.core import Results
 
 from flask import request
 from flask import Blueprint
 
-from pydantic import BaseModel
 from pydantic import ValidationError
 
 results_endpoint = Blueprint("V1 GillesPy2 Results API Endpoint", __name__, url_prefix="/results")
-
-class PlotPlotlyRequest(BaseModel):
-    result_id: str
-    args: List[str] = []
-    kwargs: Dict[str, Any] = {}
-
-class AverageEnsembleRequest(BaseModel):
-    result_id: str
 
 @results_endpoint.route("/plotplotly", methods=["POST"])
 def plotplotly():

--- a/stochss_compute/api/v1/job.py
+++ b/stochss_compute/api/v1/job.py
@@ -1,38 +1,19 @@
 import json
 
 from gillespy2.core import Model
-from pydantic import BaseModel
 
 from flask import request
 from flask import Blueprint
 
+from stochss_compute.api.dataclass import (
+    ErrorResponse,
+    StartJobRequest,
+    StartJobResponse,
+    JobStatusResponse,
+    JobStopResponse
+)
+
 from .apiutils import delegate
-
-class StartJobRequest(BaseModel):
-    job_id: str
-    model: str
-    args: str
-    kwargs: str
-
-class StartJobResponse(BaseModel):
-    job_id: str
-    msg: str
-    status: str
-
-class JobStatusResponse(BaseModel):
-    job_id: str
-    status_id: int
-    status_msg: str
-    is_complete: bool
-    has_failed: bool
-
-class JobStopResponse(BaseModel):
-    job_id: str
-    msg: str
-    success: bool
-
-class ErrorResponse(BaseModel):
-    msg: str
 
 v1_job = Blueprint("V1 Job API Endpoint", __name__, url_prefix="/job")
 

--- a/stochss_compute/api/v1/memory.py
+++ b/stochss_compute/api/v1/memory.py
@@ -1,3 +1,4 @@
+from msilib.schema import Error
 import os
 import bz2
 import tempfile
@@ -11,10 +12,12 @@ from matplotlib import pyplot
 
 from gillespy2.core import Results
 
-from .apiutils import delegate
+from stochss_compute.api.dataclass import (
+    ErrorResponse,
+    StartJobResponse
+)
 
-from .job import ErrorResponse
-from .job import StartJobResponse
+from .apiutils import delegate
 
 v1_memory = Blueprint("V1 Result API Endpoint", __name__, url_prefix="memory/")
 

--- a/stochss_compute/remote_results.py
+++ b/stochss_compute/remote_results.py
@@ -17,11 +17,13 @@ from .compute_server import ComputeServer
 
 from .remote_utils import unwrap_or_err
 
-from .api.v1.job import ErrorResponse
-from .api.v1.job import StartJobResponse
-from .api.v1.job import JobStatusResponse
-from .api.v1.gillespy2.results import PlotPlotlyRequest
-from .api.v1.gillespy2.results import AverageEnsembleRequest
+from stochss_compute.api.dataclass import (
+    ErrorResponse,
+    StartJobResponse,
+    JobStatusResponse,
+    PlotPlotlyRequest,
+    AverageEnsembleRequest
+)
 
 class RemoteResults(Results):
     def __init__(self, result_id: str, server: ComputeServer):

--- a/stochss_compute/remote_simulation.py
+++ b/stochss_compute/remote_simulation.py
@@ -14,14 +14,10 @@ from .compute_server import ComputeServer
 
 from .remote_results import RemoteResults
 
-from .api.v1.gillespy2.model import ModelRunRequest
-
-from .api.v1.job import (
-    StartJobRequest,
-    StartJobResponse,
-    JobStatusResponse,
-    JobStopResponse,
-    ErrorResponse
+from stochss_compute.api.dataclass import (
+    ErrorResponse,
+    ModelRunRequest,
+    JobStatusResponse
 )
 
 class RemoteSimulation():

--- a/stochss_compute/remote_utils.py
+++ b/stochss_compute/remote_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from requests import Response
 from pydantic import BaseModel
 
-from .api.v1.job import ErrorResponse
+from stochss_compute.api.dataclass import ErrorResponse
 
 def unwrap_or_err(response_model: type[BaseModel], response: Response):
     if not response.ok:


### PR DESCRIPTION
Resolves #71 

## Changes
- Added `stochss_compute.api.dataclass` module and moved all model definitions into it.
- Added import guard to `stochss_compute/api/__init__.py` to swallow `ImportError` exceptions in environments where Flask is not installed. 
  _Note that environments where Flask is installed but other server dependencies are missing can cause unintended behavior._
- Adjusted model imports throughout codebase to utilize `stochss_compute.api.dataclass`.
- Removed `stochss_compute/api/v1/dataclass.py`
- Removed `stochss_compute/api/v1/gillespy2/dataclass.py`